### PR TITLE
Fix error, now pass array data and not an object

### DIFF
--- a/src/core/Http/Response.php
+++ b/src/core/Http/Response.php
@@ -89,7 +89,7 @@ class Response extends HttpResponse
         if ($session['user']['loggedin'] ?? false)
         {
             $this->eventDispatcher->dispatch($args, EveryRequest::HEADER_AUTHENTICATED);
-            modulehook('everyheader-loggedin', $args);
+            modulehook('everyheader-loggedin', $args->getData());
         }
 
         calculate_buff_fields();


### PR DESCRIPTION
Fix error, now pass array data and not an object
`modulehook('everyheader-loggedin', $args);` to `modulehook('everyheader-loggedin', $args->getData());`